### PR TITLE
update footer privacy link .

### DIFF
--- a/src/index.html.handlebars
+++ b/src/index.html.handlebars
@@ -89,7 +89,7 @@
             </nav>
 
             <small class="legal">Braintree is a service of PayPal, Inc. © 2008 - <span id="current-year"></span> PayPal, Inc.
-        <a target="_blank" href="https://www.paypal.com/uk/webapps/mpp/ua/privacy-full">Privacy Policy</a> | <a target="_blank" href="https://www.braintreepayments.com/legal">Legal</a></small>
+        <a target="_blank" href="https://www.braintreepayments.com/legal/braintree-privacy-policy">Privacy Policy</a> | <a target="_blank" href="https://www.braintreepayments.com/legal">Legal</a></small>
         </div>
     </footer>
 


### PR DESCRIPTION
use https://www.braintreepayments.com/legal/braintree-privacy-policy instead of https://www.paypal.com/uk/webapps/mpp/ua/privacy-full . see #BTSITES-466