### PR TITLE
Removing references to Medium tech blog

### DIFF
--- a/build.js
+++ b/build.js
@@ -3,21 +3,12 @@ const inplace = require('metalsmith-in-place');
 const sass  = require('metalsmith-sass');
 const GitHubApi = require("github");
 const jsonfile = require("jsonfile");
-const Parser = require('rss-parser');
 
 const githubAuthFile = process.env.GH_AUTH_FILE || ".github_api_auth";
 const repositoryListFileName = process.env.REPO_LIST_FILE || "repository-list.json"
 
 console.log("Using GH_AUTH_FILE=" + githubAuthFile);
 console.log("Using REPO_LIST_FILE=" + repositoryListFileName);
-
-let parser = new Parser();
-
-async function getMediumFeed() {
-  let feed = await parser.parseURL('https://medium.com/feed/braintree-product-technology');
-
-  return feed.items.slice(0,4);
-}
 
 var github = new GitHubApi({
   headers: {
@@ -67,21 +58,18 @@ async function fetchRepositoryData(filename) {
 fetchRepositoryData(repositoryListFileName).then(repositories => {
   console.log("Updated " + repositories.length + " repositories");
 
-  getMediumFeed().then(posts => {
-    Metalsmith(__dirname)
-    .metadata({
-      repositories: repositories,
-      posts: posts
-    })
-    .source('./src')
-    .destination('.')
-    .clean(false)
-    .use(sass({
-      outputDir: 'css/'
-    }))
-    .use(inplace())
-    .build(function(err) {
-      if (err) throw err;
-    });
+  Metalsmith(__dirname)
+  .metadata({
+    repositories: repositories
   })
+  .source('./src')
+  .destination('.')
+  .clean(false)
+  .use(sass({
+    outputDir: 'css/'
+  }))
+  .use(inplace())
+  .build(function(err) {
+    if (err) throw err;
+  });
 });

--- a/index.html
+++ b/index.html
@@ -33,7 +33,6 @@
           <a target="_blank" href="https://developers.braintreepayments.com" id="developers">Documentation</a>
           <a target="_blank" href="https://www.braintreepayments.com/about" id="about">About</a>
           <a target="_blank" href="https://www.braintreepayments.com/careers" id="careers">Careers</a>
-          <a target="_blank" href="https://medium.com/braintree-product-technology" id="medium" class=""><svg width="30" height="30" fill="none" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0)"><path d="M29.772 0H0v29.772h29.772V0z" fill="#202020"/><path d="M7.104 9.957a.775.775 0 0 0-.252-.653l-1.867-2.25v-.336h5.798l4.482 9.83 3.94-9.83h5.528v.336l-1.596 1.53a.466.466 0 0 0-.178.449V20.28c-.029.17.04.343.178.448l1.559 1.531v.336h-7.844v-.336l1.616-1.568c.159-.159.159-.205.159-.448v-9.092l-4.492 11.407h-.607L8.3 11.152v7.645c-.043.321.063.645.29.877l2.1 2.549v.336H4.733v-.336l2.101-2.549c.225-.232.326-.558.271-.877v-8.84z" fill="#fff"/></g><defs><clipPath id="clip0"><path fill="#fff" d="M0 0h29.772v29.772H0z"/></clipPath></defs></svg></a>
           <a target="_blank" href="https://twitter.com/BraintreeEng" id="medium" class=""><svg width="30" height="26" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9.434 25.19c11.321 0 17.513-9.379 17.513-17.512 0-.267 0-.532-.018-.796A12.524 12.524 0 0 0 30 3.696a12.285 12.285 0 0 1-3.535.969A6.177 6.177 0 0 0 29.17 1.26a12.335 12.335 0 0 1-3.909 1.494 6.16 6.16 0 0 0-10.489 5.614A17.474 17.474 0 0 1 2.088 1.937a6.16 6.16 0 0 0 1.906 8.216 6.109 6.109 0 0 1-2.794-.77v.078a6.157 6.157 0 0 0 4.938 6.034 6.144 6.144 0 0 1-2.78.105 6.162 6.162 0 0 0 5.751 4.275A12.35 12.35 0 0 1 0 22.425a17.424 17.424 0 0 0 9.434 2.76" fill="#202020"/></svg></a>
           <a target="_blank" href="https://github.com/braintree" id="medium" class=""><svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15 0.371094C6.7125 0.371094 0 7.08734 0 15.3711C0 21.9998 4.2975 27.6211 10.2562 29.6023C11.0062 29.7436 11.2812 29.2798 11.2812 28.8811C11.2812 28.5248 11.2688 27.5811 11.2625 26.3311C7.09 27.2361 6.21 24.3186 6.21 24.3186C5.5275 22.5873 4.54125 22.1248 4.54125 22.1248C3.1825 21.1948 4.64625 21.2136 4.64625 21.2136C6.1525 21.3186 6.94375 22.7586 6.94375 22.7586C8.28125 25.0523 10.455 24.3898 11.3125 24.0061C11.4475 23.0361 11.8338 22.3748 12.2625 21.9998C8.93125 21.6248 5.43 20.3348 5.43 14.5873C5.43 12.9498 6.01125 11.6123 6.97375 10.5623C6.805 10.1836 6.29875 8.65859 7.105 6.59234C7.105 6.59234 8.36125 6.18984 11.23 8.12984C12.43 7.79609 13.705 7.63109 14.98 7.62359C16.255 7.63109 17.53 7.79609 18.73 8.12984C21.58 6.18984 22.8362 6.59234 22.8362 6.59234C23.6425 8.65859 23.1362 10.1836 22.9862 10.5623C23.9425 11.6123 24.5237 12.9498 24.5237 14.5873C24.5237 20.3498 21.0175 21.6186 17.68 21.9873C18.205 22.4373 18.6925 23.3573 18.6925 24.7623C18.6925 26.7698 18.6738 28.3823 18.6738 28.8698C18.6738 29.2636 18.9362 29.7323 19.705 29.5823C25.7063 27.6148 30 21.9898 30 15.3711C30 7.08734 23.2837 0.371094 15 0.371094" fill="#202020"/></svg></a>
       </nav>
@@ -44,40 +43,12 @@
     </div>
 
       <div class="feature">
-        <div class="feature-container">
-          <h3 class="heading--knockout">Posts</h3>
-            <a target="_blank" class="feature__item" href="https://medium.com/braintree-product-technology/handling-revoked-payment-methods-94f4e511db3b?source&#x3D;rss----ed2fd4827b5b---4">
-              <h2>Handling Revoked Payment Methods</h2>
-              <p>Alan Buttars</p>
-              <ul class="tags"><li class="tag">#webhooks</li><li class="tag">#payments</li><li class="tag">#user-experience</li></ul>
-            </a>
-            <a target="_blank" class="feature__item" href="https://medium.com/braintree-product-technology/https-medium-com-braintree-product-technology-our-design-system-is-a-meeting-60512af9696?source&#x3D;rss----ed2fd4827b5b---4">
-              <h2>Our design system is a meeting</h2>
-              <p>Shannon Miwa</p>
-              <ul class="tags"><li class="tag">#design</li><li class="tag">#communication</li><li class="tag">#ui</li><li class="tag">#user-experience</li><li class="tag">#design-systems</li></ul>
-            </a>
-            <a target="_blank" class="feature__item" href="https://medium.com/braintree-product-technology/telling-a-story-with-user-behavior-data-3a57ecffd8f1?source&#x3D;rss----ed2fd4827b5b---4">
-              <h2>Telling a Story with User Behavior Data</h2>
-              <p>Grace Greenwood</p>
-              <ul class="tags"><li class="tag">#behavioral-analytics</li><li class="tag">#documentation</li><li class="tag">#analytics</li><li class="tag">#user-experience</li><li class="tag">#ux-research</li></ul>
-            </a>
-            <a target="_blank" class="feature__item" href="https://medium.com/braintree-product-technology/how-we-built-a-shared-ui-component-library-e351c92dcfb3?source&#x3D;rss----ed2fd4827b5b---4">
-              <h2>How We Built a Shared UI Component Library</h2>
-              <p>Erica Sosa</p>
-              <ul class="tags"><li class="tag">#component-libraries</li><li class="tag">#javascript</li><li class="tag">#front-end-development</li><li class="tag">#ui</li><li class="tag">#react</li></ul>
-            </a>
-        </div>
-        <a class="feature-more-link hide-for-medium" href="https://medium.com/braintree-product-technology" target="_blank" title="More on Medium">
-          <svg width="43" height="43" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15.6 31.727l9.483-9.485v6.425h3.583V16.125H16.125v3.583h6.425l-9.484 9.484 2.534 2.535z" fill="#202020"/><path d="M35.833 8.958H10.75v3.584h21.5v21.5h3.583V8.958z" fill="#202020"/></svg>
-        </a>
-      </div>
-
-      <div class="feature">
           <div class="feature-container">
               <h3 class="heading--knockout">Projects</h3>
                 <a target="_blank" class="feature__item" href="https://github.com/braintree/wrap-promise">
                   <div class="item__content">
                       <h4>
+                      <span class="item__lang">TypeScript</span>
                       <span class="item__lang">JavaScript</span>
                   </h4>
                       <h2>wrap-promise</h2>
@@ -89,7 +60,6 @@
                       <h4>
                       <span class="item__lang">Java</span>
                       <span class="item__lang">Ruby</span>
-                      <span class="item__lang">Shell</span>
                   </h4>
                       <h2>popup-bridge-android</h2>
                       <p>PopupBridge allows WebViews to open popup windows in a browser and send data back to the WebView</p>
@@ -109,7 +79,7 @@
                 <a target="_blank" class="feature__item" href="https://github.com/braintree/credit-card-type">
                   <div class="item__content">
                       <h4>
-                      <span class="item__lang">JavaScript</span>
+                      <span class="item__lang">TypeScript</span>
                   </h4>
                       <h2>credit-card-type</h2>
                       <p>A library for determining credit card type</p>
@@ -119,6 +89,7 @@
                   <div class="item__content">
                       <h4>
                       <span class="item__lang">Java</span>
+                      <span class="item__lang">Ruby</span>
                       <span class="item__lang">Shell</span>
                   </h4>
                       <h2>browser-switch-android</h2>
@@ -130,6 +101,7 @@
                       <h4>
                       <span class="item__lang">Objective-C</span>
                       <span class="item__lang">Ruby</span>
+                      <span class="item__lang">Swift</span>
                   </h4>
                       <h2>popup-bridge-ios</h2>
                       <p>Enable your web view to open pages in a Safari View Controller</p>
@@ -149,6 +121,7 @@
                       <h4>
                       <span class="item__lang">CSS</span>
                       <span class="item__lang">JavaScript</span>
+                      <span class="item__lang">Shell</span>
                   </h4>
                       <h2>jsdoc-template</h2>
                       <p>A clean, responsive documentation template with search and navigation highlighting for JSDoc 3</p>
@@ -157,8 +130,8 @@
                 <a target="_blank" class="feature__item" href="https://github.com/braintree/restricted-input">
                   <div class="item__content">
                       <h4>
+                      <span class="item__lang">TypeScript</span>
                       <span class="item__lang">JavaScript</span>
-                      <span class="item__lang">Ruby</span>
                       <span class="item__lang">HTML</span>
                       <span class="item__lang">Shell</span>
                   </h4>
@@ -178,7 +151,7 @@
                 <a target="_blank" class="feature__item" href="https://github.com/braintree/inject-stylesheet">
                   <div class="item__content">
                       <h4>
-                      <span class="item__lang">JavaScript</span>
+                      <span class="item__lang">TypeScript</span>
                   </h4>
                       <h2>inject-stylesheet</h2>
                       <p>Create a &lt;style&gt; element with CSS properties, filtering input using a whitelist or blacklist</p>
@@ -187,7 +160,7 @@
                 <a target="_blank" class="feature__item" href="https://github.com/braintree/iframer">
                   <div class="item__content">
                       <h4>
-                      <span class="item__lang">JavaScript</span>
+                      <span class="item__lang">TypeScript</span>
                   </h4>
                       <h2>iframer</h2>
                       <p>Create consistent iframes</p>
@@ -196,6 +169,7 @@
                 <a target="_blank" class="feature__item" href="https://github.com/braintree/framebus">
                   <div class="item__content">
                       <h4>
+                      <span class="item__lang">TypeScript</span>
                       <span class="item__lang">JavaScript</span>
                       <span class="item__lang">HTML</span>
                   </h4>
@@ -206,6 +180,7 @@
                 <a target="_blank" class="feature__item" href="https://github.com/braintree/card-validator">
                   <div class="item__content">
                       <h4>
+                      <span class="item__lang">TypeScript</span>
                       <span class="item__lang">JavaScript</span>
                   </h4>
                       <h2>card-validator</h2>
@@ -215,6 +190,7 @@
                 <a target="_blank" class="feature__item" href="https://github.com/braintree/us-bank-account-validator">
                   <div class="item__content">
                       <h4>
+                      <span class="item__lang">TypeScript</span>
                       <span class="item__lang">JavaScript</span>
                   </h4>
                       <h2>us-bank-account-validator</h2>

--- a/package.json
+++ b/package.json
@@ -23,11 +23,10 @@
     "handlebars": "^4.0.6",
     "jsonfile": "^2.4.0",
     "jstransformer-handlebars": "^1.0.0",
-    "metalsmith": "^2.3.0",
+    "metalsmith": "^2.5.1",
     "metalsmith-data-loader": "^1.0.3",
     "metalsmith-in-place": "^2.0.1",
     "metalsmith-sass": "^1.4.0",
-    "metalsmith-templates": "^0.7.0",
-    "rss-parser": "^3.7.1"
+    "metalsmith-templates": "^0.7.0"
   }
 }

--- a/src/index.html.handlebars
+++ b/src/index.html.handlebars
@@ -33,7 +33,6 @@
           <a target="_blank" href="https://developers.braintreepayments.com" id="developers">Documentation</a>
           <a target="_blank" href="https://www.braintreepayments.com/about" id="about">About</a>
           <a target="_blank" href="https://www.braintreepayments.com/careers" id="careers">Careers</a>
-          <a target="_blank" href="https://medium.com/braintree-product-technology" id="medium" class=""><svg width="30" height="30" fill="none" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0)"><path d="M29.772 0H0v29.772h29.772V0z" fill="#202020"/><path d="M7.104 9.957a.775.775 0 0 0-.252-.653l-1.867-2.25v-.336h5.798l4.482 9.83 3.94-9.83h5.528v.336l-1.596 1.53a.466.466 0 0 0-.178.449V20.28c-.029.17.04.343.178.448l1.559 1.531v.336h-7.844v-.336l1.616-1.568c.159-.159.159-.205.159-.448v-9.092l-4.492 11.407h-.607L8.3 11.152v7.645c-.043.321.063.645.29.877l2.1 2.549v.336H4.733v-.336l2.101-2.549c.225-.232.326-.558.271-.877v-8.84z" fill="#fff"/></g><defs><clipPath id="clip0"><path fill="#fff" d="M0 0h29.772v29.772H0z"/></clipPath></defs></svg></a>
           <a target="_blank" href="https://twitter.com/BraintreeEng" id="medium" class=""><svg width="30" height="26" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9.434 25.19c11.321 0 17.513-9.379 17.513-17.512 0-.267 0-.532-.018-.796A12.524 12.524 0 0 0 30 3.696a12.285 12.285 0 0 1-3.535.969A6.177 6.177 0 0 0 29.17 1.26a12.335 12.335 0 0 1-3.909 1.494 6.16 6.16 0 0 0-10.489 5.614A17.474 17.474 0 0 1 2.088 1.937a6.16 6.16 0 0 0 1.906 8.216 6.109 6.109 0 0 1-2.794-.77v.078a6.157 6.157 0 0 0 4.938 6.034 6.144 6.144 0 0 1-2.78.105 6.162 6.162 0 0 0 5.751 4.275A12.35 12.35 0 0 1 0 22.425a17.424 17.424 0 0 0 9.434 2.76" fill="#202020"/></svg></a>
           <a target="_blank" href="https://github.com/braintree" id="medium" class=""><svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15 0.371094C6.7125 0.371094 0 7.08734 0 15.3711C0 21.9998 4.2975 27.6211 10.2562 29.6023C11.0062 29.7436 11.2812 29.2798 11.2812 28.8811C11.2812 28.5248 11.2688 27.5811 11.2625 26.3311C7.09 27.2361 6.21 24.3186 6.21 24.3186C5.5275 22.5873 4.54125 22.1248 4.54125 22.1248C3.1825 21.1948 4.64625 21.2136 4.64625 21.2136C6.1525 21.3186 6.94375 22.7586 6.94375 22.7586C8.28125 25.0523 10.455 24.3898 11.3125 24.0061C11.4475 23.0361 11.8338 22.3748 12.2625 21.9998C8.93125 21.6248 5.43 20.3348 5.43 14.5873C5.43 12.9498 6.01125 11.6123 6.97375 10.5623C6.805 10.1836 6.29875 8.65859 7.105 6.59234C7.105 6.59234 8.36125 6.18984 11.23 8.12984C12.43 7.79609 13.705 7.63109 14.98 7.62359C16.255 7.63109 17.53 7.79609 18.73 8.12984C21.58 6.18984 22.8362 6.59234 22.8362 6.59234C23.6425 8.65859 23.1362 10.1836 22.9862 10.5623C23.9425 11.6123 24.5237 12.9498 24.5237 14.5873C24.5237 20.3498 21.0175 21.6186 17.68 21.9873C18.205 22.4373 18.6925 23.3573 18.6925 24.7623C18.6925 26.7698 18.6738 28.3823 18.6738 28.8698C18.6738 29.2636 18.9362 29.7323 19.705 29.5823C25.7063 27.6148 30 21.9898 30 15.3711C30 7.08734 23.2837 0.371094 15 0.371094" fill="#202020"/></svg></a>
       </nav>
@@ -42,22 +41,6 @@
     <div class="hero">
         <h1>We're proud to support and participate in the <strong>open source</strong> community.</h1>
     </div>
-
-      <div class="feature">
-        <div class="feature-container">
-          <h3 class="heading--knockout">Posts</h3>
-          {{#each posts}}
-            <a target="_blank" class="feature__item" href="{{this.link}}">
-              <h2>{{this.title}}</h2>
-              <p>{{this.creator}}</p>
-              <ul class="tags">{{#each this.categories}}<li class="tag">#{{this}}</li>{{/each}}</ul>
-            </a>
-          {{/each}}
-        </div>
-        <a class="feature-more-link hide-for-medium" href="https://medium.com/braintree-product-technology" target="_blank" title="More on Medium">
-          <svg width="43" height="43" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15.6 31.727l9.483-9.485v6.425h3.583V16.125H16.125v3.583h6.425l-9.484 9.484 2.534 2.535z" fill="#202020"/><path d="M35.833 8.958H10.75v3.584h21.5v21.5h3.583V8.958z" fill="#202020"/></svg>
-        </a>
-      </div>
 
       <div class="feature">
           <div class="feature-container">


### PR DESCRIPTION
The Braintree product and technology tech blog has moved to https://medium.com/paypal-tech

This change removes any legacy references to the old blog.